### PR TITLE
 Fix: No Sound on First Click of Drum  

### DIFF
--- a/app/src/main/java/com/zendalona/mathmantra/ui/TapTablaFragment.java
+++ b/app/src/main/java/com/zendalona/mathmantra/ui/TapTablaFragment.java
@@ -31,6 +31,7 @@ public class TapTablaFragment extends Fragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         soundEffectUtility = SoundEffectUtility.getInstance(requireContext());
+        soundEffectUtility.loadSound(R.raw.drums_sound);
     }
 
     @Override


### PR DESCRIPTION
# 📌 Fix: No Sound on First Click of Drum 

## 📝 Description  
This PR fixes a bug where the drum sound did not play on the first tap when the app was opened for the first time, even though it worked properly on subsequent taps. The issue has been resolved by properly initializing the drum sound system before the first tap.  

## Before

https://github.com/user-attachments/assets/d9581e50-b42b-4656-a7e4-6d9cefd0c12e

## After

https://github.com/user-attachments/assets/773bd11d-8d8a-4938-8c51-abeeb04ec4fd

