### PR TITLE
Fix: App close on system back button press

### DIFF
--- a/app/src/main/java/com/zendalona/mathmantra/MainActivity.java
+++ b/app/src/main/java/com/zendalona/mathmantra/MainActivity.java
@@ -7,6 +7,8 @@ import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
+import androidx.activity.OnBackPressedCallback;
+import androidx.activity.OnBackPressedDispatcher;
 
 import android.os.Bundle;
 import android.util.Log;
@@ -33,7 +35,27 @@ public class MainActivity extends AppCompatActivity implements FragmentNavigatio
         controller.hide(WindowInsetsCompat.Type.statusBars() | WindowInsetsCompat.Type.navigationBars());
         controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
 
-        if (savedInstanceState == null) loadFragment(new DashboardFragment(), FragmentTransaction.TRANSIT_FRAGMENT_OPEN);
+        // Handle back button press using OnBackPressedDispatcher
+        OnBackPressedDispatcher onBackPressedDispatcher = getOnBackPressedDispatcher();
+        onBackPressedDispatcher.addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                FragmentManager fragmentManager = getSupportFragmentManager();
+                if (fragmentManager.getBackStackEntryCount() > 0) {
+                    fragmentManager.popBackStack();
+                } else {
+                    finish();
+                }
+            }
+        });
+
+        if (savedInstanceState == null) {
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+            fragmentTransaction.replace(binding.fragmentContainer.getId(), new DashboardFragment());
+            fragmentTransaction.commit();
+        }
+
 
         setSupportActionBar(binding.toolbar);
         ActionBar actionBar = getSupportActionBar();
@@ -74,6 +96,7 @@ public class MainActivity extends AppCompatActivity implements FragmentNavigatio
         fragmentTransaction.setTransition(transition);
         fragmentTransaction.replace(binding.fragmentContainer.getId(), fragment);
         // TODO : binding.toolbar.setTitle();
+        fragmentTransaction.addToBackStack(null);
         fragmentTransaction.commit();
     }
 


### PR DESCRIPTION
# 📌 Fix: App close on system back button press


## 📝 Description  
This pull request resolves a bug where clicking the toolbar action button navigates to the previous screen. If the user is on the home screen, the app will close. Additionally, when using the system back button, the app previously closed directly instead of navigating back. With these changes, pressing the system back button now navigates to the previous screen and only closes the app when no previous screen exists.

## Before
https://github.com/user-attachments/assets/65d703e6-dec1-4b1a-83d5-b63c1b49ed69


## After 
https://github.com/user-attachments/assets/72d4a6ea-1ae8-4cda-aedd-22fda801bd59

