### PR TITLE
Fix: App crashes in single choice questions

### DIFF
--- a/app/src/main/java/com/zendalona/mathmantra/ui/MathQuizFragment.java
+++ b/app/src/main/java/com/zendalona/mathmantra/ui/MathQuizFragment.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.zendalona.mathmantra.R;
@@ -50,8 +51,15 @@ public class MathQuizFragment extends Fragment {
                 .append(" = ?");
         binding.answerEt.setText("");
         binding.questionTv.setText(questionBuilder);
-        binding.submitAnswerBtn
-                .setOnClickListener(v -> showResultDialog(Integer.parseInt(binding.answerEt.getText().toString()) == numbers[2]));
+        binding.submitAnswerBtn.setOnClickListener(v -> {
+            String answerText = binding.answerEt.getText().toString().trim();
+            if (answerText.isEmpty()) {
+                Toast.makeText(getContext(), "Please enter an answer", Toast.LENGTH_SHORT).show();
+                return;
+            }
+            int answer = Integer.parseInt(answerText);
+            showResultDialog(answer == numbers[2]);
+        });
     }
 
     private void showResultDialog(boolean isCorrect) {


### PR DESCRIPTION
# 📌 Fix: App crashes in single choice questions


## 📝 Description  
This PR fixes a bug that caused the app to crash when a user clicked the submit button without entering an answer. The issue has been resolved so that if the input is empty, a toast message is displayed instead of crashing the app.


## Before

https://github.com/user-attachments/assets/63db5681-f803-46c6-b82f-a7211d92f024



## After

https://github.com/user-attachments/assets/4ff6a08a-acf3-479f-8684-709441d10f51

