### PR TITLE
stop TTS output when leaving number line fragment

### DIFF
--- a/app/src/main/java/com/zendalona/mathmantra/ui/NumberLineFragment.java
+++ b/app/src/main/java/com/zendalona/mathmantra/ui/NumberLineFragment.java
@@ -57,6 +57,9 @@ public class NumberLineFragment extends Fragment {
     public void onPause() {
         super.onPause();
 //        requireActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        if (tts != null) {
+            tts.stopSpeaking();  // Add a stop method in TTSUtility if not present
+        }
     }
 
     @Override
@@ -167,10 +170,12 @@ public class NumberLineFragment extends Fragment {
 //        tts.speak("Click on continue!");
     }
 
-
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        if (tts != null) {
+            tts.shutdown();  // Properly release TTS resources
+        }
         binding = null;
     }
 }

--- a/app/src/main/java/com/zendalona/mathmantra/ui/TapTablaFragment.java
+++ b/app/src/main/java/com/zendalona/mathmantra/ui/TapTablaFragment.java
@@ -95,7 +95,7 @@ public class TapTablaFragment extends Fragment {
     public void onDestroyView() {
         super.onDestroyView();
         if (tts != null) {
-            tts.shutdown();
+            tts.shutdown();  // Properly release TTS resources
         }
         // Release resources related to binding
         binding = null;

--- a/app/src/main/java/com/zendalona/mathmantra/ui/TapTablaFragment.java
+++ b/app/src/main/java/com/zendalona/mathmantra/ui/TapTablaFragment.java
@@ -94,6 +94,9 @@ public class TapTablaFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        if (tts != null) {
+            tts.shutdown();  // Properly release TTS resources
+        }
         // Release resources related to binding
         binding = null;
     }

--- a/app/src/main/java/com/zendalona/mathmantra/ui/TapTablaFragment.java
+++ b/app/src/main/java/com/zendalona/mathmantra/ui/TapTablaFragment.java
@@ -95,7 +95,7 @@ public class TapTablaFragment extends Fragment {
     public void onDestroyView() {
         super.onDestroyView();
         if (tts != null) {
-            tts.shutdown();  // Properly release TTS resources
+            tts.shutdown();
         }
         // Release resources related to binding
         binding = null;

--- a/app/src/main/java/com/zendalona/mathmantra/utils/TTSUtility.java
+++ b/app/src/main/java/com/zendalona/mathmantra/utils/TTSUtility.java
@@ -29,11 +29,12 @@ public class TTSUtility {
         tts.setSpeechRate(rate);
     }
 
-    public void stop() {
-        if (tts != null) {
+    public void stopSpeaking() {
+        if (tts != null && tts.isSpeaking()) {
             tts.stop();
         }
     }
+
 
     public void shutdown() {
         if (tts != null) {


### PR DESCRIPTION
Fix #10: Stop TTS playback when navigating away from NumberLineFragment

Issue
The TTS continues playing even after navigating away from Number Line screen.
This happens when the fragment is left without stopping the TTS.

https://github.com/user-attachments/assets/1da9bc26-7161-4aed-814f-8bb9dd99e801

Solution
tts.stop() added in onPause() to stop speech when the fragment is not active.
tts.shutdown() added in onDestroyView() to release resources.

https://github.com/user-attachments/assets/a7a5f2d9-002e-466c-972f-42d49f414d2e

Testing
Navigated to Number Line screen → TTS plays the question.
Pressed back button → TTS stops immediately.
No memory leaks or crashes observed.